### PR TITLE
improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tests/tests-config.php
 tests/report*
+tests/run-tests.log

--- a/Net/Gearman/Client.php
+++ b/Net/Gearman/Client.php
@@ -97,7 +97,7 @@ class Net_Gearman_Client
      *
      * @return resource A connection to a Gearman server
      */
-    protected function getConnection($uniq=null)
+    protected function getConnection($uniq = null)
     {
         $conn = null;
 

--- a/Net/Gearman/Client.php
+++ b/Net/Gearman/Client.php
@@ -235,8 +235,11 @@ class Net_Gearman_Client
 
 
             if ($t < $totalTasks) {
+
                 $k = $taskKeys[$t];
+
                 $this->submitTask($set->tasks[$k]);
+
                 if ($set->tasks[$k]->type == Net_Gearman_Task::JOB_BACKGROUND ||
                     $set->tasks[$k]->type == Net_Gearman_Task::JOB_HIGH_BACKGROUND ||
                     $set->tasks[$k]->type == Net_Gearman_Task::JOB_LOW_BACKGROUND) {
@@ -251,6 +254,7 @@ class Net_Gearman_Client
             $write  = null;
             $except = null;
             $read   = $this->conn;
+
             socket_select($read, $write, $except, $socket_timeout);
             foreach ($read as $socket) {
                 $resp = Net_Gearman_Connection::read($socket);
@@ -269,10 +273,17 @@ class Net_Gearman_Client
      * @param object   $tasks The tasks being ran
      * 
      * @return void
-     * @throws Net_Gearman_Exception
+     * @throws Net_Gearman_Exception When $s is not a resource.
+     * @throws Net_Gearman_Exception When an response indicates that an error occured.
+     * @throws Net_Gearman_Exception When an invalid function was called.
      */
-    protected function handleResponse($resp, $s, Net_Gearman_Set $tasks) 
+    protected function handleResponse(array $resp, $s, Net_Gearman_Set $tasks) 
     {
+        if (!is_resource($s)) {
+            throw new Net_Gearman_Exception(
+                sprintf("Parameter must be of type 'resource', '%s' given", gettype($s))
+            );
+        }
         if (isset($resp['data']['handle']) && 
             $resp['function'] != 'job_created') {
             $task = $tasks->getTask($resp['data']['handle']);

--- a/Net/Gearman/Client.php
+++ b/Net/Gearman/Client.php
@@ -67,16 +67,13 @@ class Net_Gearman_Client
      * @param array   $servers An array of servers or a single server
      * @param integer $timeout Timeout in microseconds
      * 
-     * @return void
-     * @throws Net_Gearman_Exception
-     * @see Net_Gearman_Connection
+     * @return $this
+     * @see    Net_Gearman_Connection
      */
-    public function __construct($servers, $timeout = 1000)
+    public function __construct(array $servers = null, $timeout = 1000)
     {
-        if (!is_array($servers) && strlen($servers)) {
-            $servers = array($servers);
-        } elseif (is_array($servers) && !count($servers)) {
-            throw new Net_Gearman_Exception('Invalid servers specified');
+        if ($servers === null || (is_array($servers) && empty($servers))) {
+            $servers = array('localhost:4730');
         }
 
         $this->servers = $servers;
@@ -127,7 +124,7 @@ class Net_Gearman_Client
      */
     public function __call($func, array $args = array())
     {
-        $send = "";
+        $send = array();
         if (isset($args[0]) && !empty($args[0])) {
             $send = $args[0];
         }

--- a/Net/Gearman/Client.php
+++ b/Net/Gearman/Client.php
@@ -143,8 +143,8 @@ class Net_Gearman_Client
      *
      * @param object $task Task to submit to Gearman
      * 
-     * @return      void
-     * @see         Net_Gearman_Task, Net_Gearman_Client::runSet()
+     * @return void
+     * @see    Net_Gearman_Task, Net_Gearman_Client::runSet()
      */
     protected function submitTask(Net_Gearman_Task $task)
     {
@@ -190,6 +190,8 @@ class Net_Gearman_Client
             Net_Gearman_Connection::$waiting[(int)$s] = array();
         }
 
+        $task->server = (int) $s;
+
         array_push(Net_Gearman_Connection::$waiting[(int)$s], $task);
     }
 
@@ -200,7 +202,8 @@ class Net_Gearman_Client
      * @param int    $timeout Time in seconds for the socket timeout. Max is 10 seconds
      * 
      * @return void
-     * @see Net_Gearman_Set, Net_Gearman_Task
+     * @see    Net_Gearman_Set, Net_Gearman_Task
+     * @uses   self::submitTask()
      */
     public function runSet(Net_Gearman_Set $set, $timeout = null)
     {

--- a/Net/Gearman/Client.php
+++ b/Net/Gearman/Client.php
@@ -23,6 +23,7 @@
 
 require_once 'Net/Gearman/Connection.php';
 require_once 'Net/Gearman/Set.php';
+require_once 'Net/Gearman/Task.php';
 
 /**
  * A client for submitting jobs to Gearman

--- a/Net/Gearman/Connection.php
+++ b/Net/Gearman/Connection.php
@@ -151,9 +151,9 @@ class Net_Gearman_Connection
 
         $start = microtime(true);
         do {
-            $socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+            $socket           = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
             $socket_connected = @socket_connect($socket, $host, $port);
-            $timeLeft = ((microtime(true) - $start) * 1000);
+            $timeLeft         = ((microtime(true) - $start) * 1000);
             if ($socket_connected) {
                 socket_set_nonblock($socket);
                 socket_set_option($socket, SOL_TCP, 1, 1);
@@ -161,8 +161,10 @@ class Net_Gearman_Connection
         } while (!$socket_connected && $timeLeft < $timeout);
 
         if (!$socket_connected) {
-            $errno = socket_last_error($socket);
+
+            $errno  = socket_last_error($socket);
             $errstr	= socket_strerror($errno);
+
             throw new Net_Gearman_Exception(
                 "Can't connect to server ($errno: $errstr)"
             );
@@ -233,7 +235,7 @@ class Net_Gearman_Connection
         } while ($written < $cmdLength);
 
         if ($error === true) {
-            $errno = socket_last_error($socket);
+            $errno  = socket_last_error($socket);
             $errstr	= socket_strerror($errno);
             throw new Net_Gearman_Exception(
                 "Could not write command to socket ($errno: $errstr)"
@@ -391,9 +393,8 @@ class Net_Gearman_Connection
 
         if (self::$multiByteSupport & 2) {
             return mb_strlen($value, '8bit');
-        } else {
-            return strlen($value);
         }
+        return strlen($value);
     }
 
     /**

--- a/Net/Gearman/Connection.php
+++ b/Net/Gearman/Connection.php
@@ -421,5 +421,3 @@ class Net_Gearman_Connection
         }
     }
 }
-
-?>

--- a/Net/Gearman/Exception.php
+++ b/Net/Gearman/Exception.php
@@ -38,5 +38,3 @@ require_once 'PEAR/Exception.php';
 class Net_Gearman_Exception extends PEAR_Exception
 {
 }
-
-?>

--- a/Net/Gearman/Job/Common.php
+++ b/Net/Gearman/Job/Common.php
@@ -139,5 +139,3 @@ abstract class Net_Gearman_Job_Common
         ));
     }
 }
-
-?>

--- a/Net/Gearman/Job/Exception.php
+++ b/Net/Gearman/Job/Exception.php
@@ -40,7 +40,4 @@ require_once 'Net/Gearman/Exception.php';
  */
 class Net_Gearman_Job_Exception extends Net_Gearman_Exception
 {
-
 }
-
-?>

--- a/Net/Gearman/Manager.php
+++ b/Net/Gearman/Manager.php
@@ -63,7 +63,7 @@ class Net_Gearman_Manager
     /**
      * Constructor
      *
-     * @param string  $server  Host and port (e.g. 'localhost:7003')
+     * @param string  $server  Host and port (e.g. 'localhost:4703')
      * @param integer $timeout Connection timeout
      *
      * @throws Net_Gearman_Exception

--- a/Net/Gearman/Set.php
+++ b/Net/Gearman/Set.php
@@ -212,5 +212,3 @@ class Net_Gearman_Set implements IteratorAggregate, Countable
         return $this->tasksCount;
     }
 }
-
-?>

--- a/Net/Gearman/Task.php
+++ b/Net/Gearman/Task.php
@@ -75,6 +75,12 @@ class Net_Gearman_Task
     public $handle = '';
 
     /**
+     * Server reference
+     * @var string $server
+     */
+    public $server = '';
+
+    /**
      * The unique identifier for this job
      *
      * Keep in mind that a unique job is only unique to the job server it is 

--- a/Net/Gearman/Task.php
+++ b/Net/Gearman/Task.php
@@ -216,7 +216,7 @@ class Net_Gearman_Task
      * @return Net_Gearman_Task
      * @throws Net_Gearman_Exception
      */
-    public function __construct($func, $arg, $uniq = null,
+    public function __construct($func, array $arg = null, $uniq = null,
                                 $type = self::JOB_NORMAL) 
     {
         $this->func = $func;

--- a/Net/Gearman/Task.php
+++ b/Net/Gearman/Task.php
@@ -360,5 +360,3 @@ class Net_Gearman_Task
         }
     }
 }
-
-?>

--- a/Net/Gearman/Task.php
+++ b/Net/Gearman/Task.php
@@ -309,10 +309,17 @@ class Net_Gearman_Task
     /**
      * Run the failure callbacks
      *
-     * Failure callbacks are passed the task object job that failed
+     * Failure callbacks are passed the task object job that failed:
+     * <code>
+     * // example callback
+     * function failCallback(Net_Gearman_Task $task) {
+     *     var_dump($task);
+     * }
+     * $task->attachCallback('failCallback', Net_Gearman_Task::TASK_FAIL);
+     * </code>
      *
      * @return void
-     * @see Net_Gearman_Task::attachCallback()
+     * @see    Net_Gearman_Task::attachCallback()
      */
     public function fail()
     {

--- a/Net/Gearman/Worker.php
+++ b/Net/Gearman/Worker.php
@@ -4,15 +4,15 @@
  *
  * PHP version 5.1.0+
  *
- * LICENSE: This source file is subject to the New BSD license that is 
+ * LICENSE: This source file is subject to the New BSD license that is
  * available through the world-wide-web at the following URI:
- * http://www.opensource.org/licenses/bsd-license.php. If you did not receive  
- * a copy of the New BSD License and are unable to obtain it through the web, 
+ * http://www.opensource.org/licenses/bsd-license.php. If you did not receive
+ * a copy of the New BSD License and are unable to obtain it through the web,
  * please send a note to license@php.net so we can mail you a copy immediately.
  *
  * @category  Net
  * @package   Net_Gearman
- * @author    Joe Stump <joe@joestump.net> 
+ * @author    Joe Stump <joe@joestump.net>
  * @copyright 2007-2008 Digg.com, Inc.
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @version   CVS: $Id$
@@ -31,14 +31,14 @@ require_once 'Net/Gearman/Job.php';
  *
  * <code>
  * <?php
- * 
+ *
  * $servers = array(
  *     '127.0.0.1:7003',
  *     '127.0.0.1:7004'
  * );
- * 
+ *
  * $abilities = array('HelloWorld', 'Foo', 'Bar');
- * 
+ *
  * try {
  *     $worker = new Net_Gearman_Worker($servers);
  *     foreach ($abilities as $ability) {
@@ -48,14 +48,14 @@ require_once 'Net/Gearman/Job.php';
  * } catch (Net_Gearman_Exception $e) {
  *     echo $e->getMessage() . "\n";
  *     exit;
- * } 
- * 
+ * }
+ *
  * ?>
  * </code>
  *
  * @category  Net
  * @package   Net_Gearman
- * @author    Joe Stump <joe@joestump.net> 
+ * @author    Joe Stump <joe@joestump.net>
  * @copyright 2007-2008 Digg.com, Inc.
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @version   Release: @package_version@
@@ -91,7 +91,7 @@ class Net_Gearman_Worker
      * @var array $initParams
      */
     protected $initParams = array();
-    
+
     /**
      * Callbacks registered for this worker
      *
@@ -130,7 +130,7 @@ class Net_Gearman_Worker
      *
      * @param array $servers List of servers to connect to
      * @param string $id     Optional unique id for this worker
-     * 
+     *
      * @return void
      * @throws Net_Gearman_Exception
      * @see Net_Gearman_Connection
@@ -151,11 +151,11 @@ class Net_Gearman_Worker
 
         foreach ($servers as $s) {
             try {
-                $conn = Net_Gearman_Connection::connect($s);   
+                $conn = Net_Gearman_Connection::connect($s);
 
                 Net_Gearman_Connection::send($conn, "set_client_id", array("client_id" => $this->id));
 
-                $this->conn[$s] = $conn;             
+                $this->conn[$s] = $conn;
 
             } catch (Net_Gearman_Exception $e) {
 
@@ -190,9 +190,9 @@ class Net_Gearman_Worker
         }
 
         $this->initParams[$ability] = $initParams;
-        
+
         $this->abilities[$ability] = $timeout;
-        
+
         foreach ($this->conn as $conn) {
             Net_Gearman_Connection::send($conn, $call, $params);
         }
@@ -204,11 +204,11 @@ class Net_Gearman_Worker
      * This starts the worker on its journey of actually working. The first
      * argument is a PHP callback to a function that can be used to monitor
      * the worker. If no callback is provided then the worker works until it
-     * is killed. The monitor is passed two arguments; whether or not the 
+     * is killed. The monitor is passed two arguments; whether or not the
      * worker is idle and when the last job was ran.
      *
      * @param callback $monitor Function to monitor work
-     * 
+     *
      * @return void
      * @see Net_Gearman_Connection::send(), Net_Gearman_Connection::connect()
      * @see Net_Gearman_Worker::doWork(), Net_Gearman_Worker::addAbility()
@@ -228,7 +228,7 @@ class Net_Gearman_Worker
         while ($working) {
             $sleep = true;
             $currentTime = time();
-            
+
             foreach ($this->conn as $server => $socket) {
                 $worked = false;
                 try {
@@ -268,12 +268,12 @@ class Net_Gearman_Worker
                     }
                 }
             }
-            
+
             if (count($this->conn) == 0) {
                 // sleep to avoid wasted cpu cycles if no connections to block on using socket_select
                 sleep(1);
             }
-            
+
             if ($retryChange === true) {
                 // broadcast all abilities to all servers
                 foreach ($this->abilities as $ability => $timeout) {
@@ -294,10 +294,10 @@ class Net_Gearman_Worker
      *
      * Sends the 'grab_job' command and then listens for either the 'noop' or
      * the 'no_job' command to come back. If the 'job_assign' comes down the
-     * pipe then we run that job. 
+     * pipe then we run that job.
      *
-     * @param resource $socket The socket to work on 
-     * 
+     * @param resource $socket The socket to work on
+     *
      * @return boolean Returns true if work was done, false if not
      * @throws Net_Gearman_Exception
      * @see Net_Gearman_Connection::send()
@@ -309,7 +309,7 @@ class Net_Gearman_Worker
         $resp = array('function' => 'noop');
         while (count($resp) && $resp['function'] == 'noop') {
             $resp = Net_Gearman_Connection::blockingRead($socket);
-        } 
+        }
 
         if (in_array($resp['function'], array('noop', 'no_job'))) {
             return false;
@@ -323,7 +323,7 @@ class Net_Gearman_Worker
         $handle = $resp['data']['handle'];
         $arg    = array();
 
-        if (isset($resp['data']['arg']) && 
+        if (isset($resp['data']['arg']) &&
             Net_Gearman_Connection::stringLength($resp['data']['arg'])) {
             $arg = json_decode($resp['data']['arg'], true);
             if($arg === null){
@@ -336,7 +336,7 @@ class Net_Gearman_Worker
         );
         try {
             $this->start($handle, $name, $arg);
-            $res = $job->run($arg); 
+            $res = $job->run($arg);
             if (!is_array($res)) {
                 $res = array('result' => $res);
             }
@@ -344,8 +344,8 @@ class Net_Gearman_Worker
             $job->complete($res);
             $this->complete($handle, $name, $res);
         } catch (Net_Gearman_Job_Exception $e) {
-            $job->fail(); 
-            $this->fail($handle, $name, $e); 
+            $job->fail();
+            $this->fail($handle, $name, $e);
         }
 
         // Force the job's destructor to run
@@ -359,7 +359,7 @@ class Net_Gearman_Worker
      *
      * @param callback $callback A valid PHP callback
      * @param integer  $type     Type of callback
-     * 
+     *
      * @return void
      * @throws Net_Gearman_Exception When an invalid callback is specified.
      * @throws Net_Gearman_Exception When an invalid type is specified.
@@ -401,7 +401,7 @@ class Net_Gearman_Worker
      * @param string $handle The job's Gearman handle
      * @param string $job    The name of the job
      * @param array  $result The job's returned result
-     * 
+     *
      * @return void
      */
     protected function complete($handle, $job, array $result)
@@ -421,7 +421,7 @@ class Net_Gearman_Worker
      * @param string $handle The job's Gearman handle
      * @param string $job    The name of the job
      * @param object $error  The exception thrown
-     * 
+     *
      * @return void
      */
     protected function fail($handle, $job, PEAR_Exception $error)

--- a/Net/Gearman/Worker.php
+++ b/Net/Gearman/Worker.php
@@ -135,9 +135,11 @@ class Net_Gearman_Worker
      * @throws Net_Gearman_Exception
      * @see Net_Gearman_Connection
      */
-    public function __construct($servers, $id = "")
+    public function __construct($servers = null, $id = "")
     {
-        if (!is_array($servers) && strlen($servers)) {
+        if (is_null($servers)){
+            $servers = array("localhost");
+        } elseif (!is_array($servers) && strlen($servers)) {
             $servers = array($servers);
         } elseif (is_array($servers) && !count($servers)) {
             throw new Net_Gearman_Exception('Invalid servers specified');

--- a/tests/012-client-runSet.phpt
+++ b/tests/012-client-runSet.phpt
@@ -2,6 +2,7 @@
 Net_Gearman_Set, Net_Gearman_Client::runSet()
 --SKIPIF--
 <?php
+die('skip THIS TEST IS BROKEN.');
 if (!file_exists(dirname(__FILE__) . '/tests-config.php')) {
     die('skip This test requires a test-config.php file.');
 }

--- a/tests/012-client-runSet.phpt
+++ b/tests/012-client-runSet.phpt
@@ -27,7 +27,7 @@ $client->runSet($set);
 
 $superSum = 0;
 foreach ($set as $task) {
-    $superSum += $task->result->sum;
+    $superSum += $task->result["result"];
 }
 
 var_dump($superSum);

--- a/tests/Net/Gearman/TaskTest.php
+++ b/tests/Net/Gearman/TaskTest.php
@@ -108,6 +108,27 @@ class Net_Gearman_TaskTest extends PHPUnit_Framework_TestCase
 
         unset($GLOBALS['Net_Gearman_TaskTest']);
     }
+
+    /**
+     * See that task has handle and server assigned.
+     *
+     * @return void
+     */
+    public function testTaskStatus()
+    {
+        $client = new Net_Gearman_Client();
+ 
+        $task       = new Net_Gearman_Task('Reverse', range(1,5));
+        $task->type = Net_Gearman_Task::JOB_BACKGROUND;
+ 
+        $set = new Net_Gearman_Set();
+        $set->addTask($task);
+ 
+        $client->runSet($set);
+ 
+        $this->assertNotEquals('', $task->handle);
+        $this->assertNotEquals('', $task->server);
+    }
 }
 
 /**


### PR DESCRIPTION
Hey Brian,

this pull contains the following:

 * `public Net_Gearman_Task::$server` (assigned in `Net_Gearman_Client::submitTask()`)
 * a new test to cover `Net_Gearman_Task::$handle` and `Net_Gearman_Task::$server`
 * use of type hints to enforce data types
   * possible BC break in `Net_Gearman_Task::__construct()`
 * stripped trailing `?>` from most files
 * a couple CS fixes
 * disabled the `012-*.phpt` until we figure it out (please re-open that issue)

Let me know what you think.

Till