### PR TITLE
Made Net_Gearman_Manager::worker() more fault tolerant

### DIFF
--- a/Net/Gearman/Manager.php
+++ b/Net/Gearman/Manager.php
@@ -144,8 +144,8 @@ class Net_Gearman_Manager
                 continue;
             }
 
-            list($info, $abilities) = explode(" : ", $t);
-            list($fd, $ip, $id)     = explode(' ', $info);
+            list($info, $abilities) = explode(':', $t);
+            list($fd, $ip, $id)     = explode(' ', trim($info));
 
             $abilities = trim($abilities);
 


### PR DESCRIPTION
Under certain circumstances result from worker status command could be empty. Thus $info would not to be populated resulting in a PHP notice.

This pull request fixes this by exploding the status string a bit differently.

Cheers
Etienne
