### PR TITLE
Handle if 1000 milliseconds is set as timeout

### DIFF
--- a/Net/Gearman/Connection.php
+++ b/Net/Gearman/Connection.php
@@ -149,7 +149,7 @@ class Net_Gearman_Connection
         /**
          * Translate $timeout in milliseconds to seconds and µ seconds
          */
-        if($timeout > 1000){
+        if($timeout >= 1000){
             $ts_seconds = $timeout / 1000;
             $tv_sec = floor($ts_seconds);
             $tv_usec = ($ts_seconds - $tv_sec) * 1000000;


### PR DESCRIPTION
I think this was the intended behavior … so that 1 second goes through
the first if condition and sets the ts_sec to 1.
