### PR TITLE
Better error messages for job class lookup failure

### DIFF
--- a/Net/Gearman/Job.php
+++ b/Net/Gearman/Job.php
@@ -70,7 +70,7 @@ abstract class Net_Gearman_Job
         include_once $file;
         $class = NET_GEARMAN_JOB_CLASS_PREFIX . $job;
         if (!class_exists($class)) {
-            throw new Net_Gearman_Job_Exception('Invalid Job class: ' . (empty($class) ? '<empty>' : $file));
+            throw new Net_Gearman_Job_Exception('Invalid Job class: ' . (empty($class) ? '<empty>' : $class) . ' in ' . (empty($file) ? '<empty>' : $file) );
         }
 
         $instance = new $class($conn, $handle, $initParams);


### PR DESCRIPTION
Show better error messages if we can't find the class or we load a class of the wrong ancestry.
