### PR TITLE
Additional init params support in job factory.

### DIFF
--- a/Net/Gearman/Job.php
+++ b/Net/Gearman/Job.php
@@ -74,7 +74,7 @@ abstract class Net_Gearman_Job
         }
 
         if ( ! file_exists($file) ) {
-            throw new Net_Gearman_Job_Exception('Invalid Job class file: ' . empty($file) ? '<empty>' : $file);
+            throw new Net_Gearman_Job_Exception('Invalid Job class file: ' . (empty($file) ? '<empty>' : $file));
         }
 
         include_once $file;


### PR DESCRIPTION
Add support to pass the class file and the class name in via the
initParams array.

path: full filename to class file.
class_name: name of the class.

This will be used by GearmanManager and adds compatibility outside of PEAR and Composer loading of job classes.
