### PR TITLE
Using relative requires which are more compatible.

### DIFF
--- a/Net/Gearman/Client.php
+++ b/Net/Gearman/Client.php
@@ -21,8 +21,8 @@
  * @link      https://github.com/brianlmoon/net_gearman
  */
 
-require_once 'Net/Gearman/Connection.php';
-require_once 'Net/Gearman/Set.php';
+require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Connection.php';
+require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Set.php';
 
 /**
  * A client for submitting jobs to Gearman

--- a/Net/Gearman/Connection.php
+++ b/Net/Gearman/Connection.php
@@ -21,7 +21,7 @@
  * @link      https://github.com/brianlmoon/net_gearman
  */
 
-require_once 'Net/Gearman/Exception.php';
+require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Exception.php';
 
 /**
  * The base connection class

--- a/Net/Gearman/Exception.php
+++ b/Net/Gearman/Exception.php
@@ -21,8 +21,6 @@
  * @link      https://github.com/brianlmoon/net_gearman
  */
 
-require_once 'PEAR/Exception.php';
-
 /**
  * Exception class for Net_Gearman
  *
@@ -32,9 +30,8 @@ require_once 'PEAR/Exception.php';
  * @author    Brian Moon <brianm@dealnews.com>
  * @copyright 2007-2008 Digg.com, Inc.
  * @link      https://github.com/brianlmoon/net_gearman
- * @see       PEAR_Exception
  */
-class Net_Gearman_Exception extends PEAR_Exception
+class Net_Gearman_Exception extends Exception
 {
 
 }

--- a/Net/Gearman/Job.php
+++ b/Net/Gearman/Job.php
@@ -21,8 +21,8 @@
  * @link      https://github.com/brianlmoon/net_gearman
  */
 
-require_once 'Net/Gearman/Job/Common.php';
-require_once 'Net/Gearman/Exception.php';
+require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Job' . DIRECTORY_SEPARATOR . 'Common.php';
+require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Exception.php';
 
 // Define this if you want your Jobs to be stored in a different
 // path than the default.

--- a/Net/Gearman/Job/Common.php
+++ b/Net/Gearman/Job/Common.php
@@ -21,7 +21,7 @@
  * @link      http://www.danga.com/gearman/
  */
 
-require_once 'Net/Gearman/Job/Exception.php';
+require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Exception.php'; // Net_Gearman_Job_Exception
 
 /**
  * Base job class for all Gearman jobs

--- a/Net/Gearman/Job/Exception.php
+++ b/Net/Gearman/Job/Exception.php
@@ -5,15 +5,15 @@
  *
  * PHP version 5.1.0+
  *
- * LICENSE: This source file is subject to the New BSD license that is 
+ * LICENSE: This source file is subject to the New BSD license that is
  * available through the world-wide-web at the following URI:
- * http://www.opensource.org/licenses/bsd-license.php. If you did not receive  
- * a copy of the New BSD License and are unable to obtain it through the web, 
+ * http://www.opensource.org/licenses/bsd-license.php. If you did not receive
+ * a copy of the New BSD License and are unable to obtain it through the web,
  * please send a note to license@php.net so we can mail you a copy immediately.
  *
  * @category  Net
  * @package   Net_Gearman
- * @author    Joe Stump <joe@joestump.net> 
+ * @author    Joe Stump <joe@joestump.net>
  * @copyright 2007-2008 Digg.com, Inc.
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @version   CVS: $Id$
@@ -21,17 +21,17 @@
  * @link      http://www.danga.com/gearman/
  */
 
-require_once 'Net/Gearman/Exception.php';
+require_once dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'Exception.php';
 
 /**
  * Exception class for Gearman jobs
  *
- * Your Gearman jobs should throw this from their run() method if they run 
- * into any kind of error. 
+ * Your Gearman jobs should throw this from their run() method if they run
+ * into any kind of error.
  *
  * @category  Net
  * @package   Net_Gearman
- * @author    Joe Stump <joe@joestump.net> 
+ * @author    Joe Stump <joe@joestump.net>
  * @copyright 2007-2008 Digg.com, Inc.
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @version   Release: @package_version@

--- a/Net/Gearman/Manager.php
+++ b/Net/Gearman/Manager.php
@@ -20,7 +20,7 @@
  * @link      https://github.com/brianlmoon/net_gearman
  */
 
-require_once 'Net/Gearman/Connection.php';
+require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Connection.php';
 
 /**
  * A client for managing Gearmand servers

--- a/Net/Gearman/Set.php
+++ b/Net/Gearman/Set.php
@@ -21,7 +21,7 @@
  * @link      https://github.com/brianlmoon/net_gearman
  */
 
-require_once 'Net/Gearman/Task.php';
+require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Task.php';
 
 /**
  * A class for creating sets of tasks

--- a/Net/Gearman/Worker.php
+++ b/Net/Gearman/Worker.php
@@ -20,8 +20,8 @@
  * @link      http://www.danga.com/gearman/
  */
 
-require_once 'Net/Gearman/Connection.php';
-require_once 'Net/Gearman/Job.php';
+require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Connection.php';
+require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Job.php';
 
 /**
  * Gearman worker class


### PR DESCRIPTION
Also removes dependency on the PEAR_Exception class.  Now
Net_Gearman_Exception just extends Exception for better or worse.