### PR TITLE
Adding composer file.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "brianlmoon/net_gearman",
+    "homepage": "http://brian.moonspot.net/GearmanManager",
+    "description": "PHP daemon for managing gearman workers",
+    "keywords": ["gearman","net_gearman","gearman-manager"],
+    "type": "library",
+    "license": "BSD",
+    "authors": [
+        {
+            "name": "Brian Moon",
+            "homepage": "http://brian.moonspot.net"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/brianlmoon/net_gearman/issues"
+    },
+    "require": {
+        "php": ">=5.2.0"
+    },
+    "autoload": {
+        "classmap": [ "Net/Gearman" ]
+    }
+}


### PR DESCRIPTION
This depends on the jpirkey-more-compatible-requires branch in that
composer won’t work unless that branch is merged in.

The changes were significant enough that I figured a separate jpirkey-more-compatible-requires branch since they were independent of other changes.
