### PR TITLE
Bugfix include-path in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
     },
     "autoload": {
         "classmap": [ "Net/Gearman" ]
-    }
+    },
+    "include-path": [
+        "."
+    ]
 }


### PR DESCRIPTION
Fix "PHP Fatal error:  require_once(): Failed opening required 'Net/Gearman/Connection.php'" in Worker class.
