### PR TITLE
Fix: call fail() on a job that throws an exception

### DIFF
--- a/Net/Gearman/Worker.php
+++ b/Net/Gearman/Worker.php
@@ -366,7 +366,7 @@ class Net_Gearman_Worker
             $this->complete($handle, $name, $res);
         } catch (Net_Gearman_Job_Exception $e) {
             // If the factory method call fails, we won't have a job.
-            if (isset($job) && $job instanceof Net_Gearman_Job) {
+            if (isset($job) && $job instanceof Net_Gearman_Job_Common) {
                 $job->fail();
             }
 


### PR DESCRIPTION
`$job->fail()` was never being called when an exception was thrown during `$job->run()` because `$job` is never a instanceof `Net_Gearman_Job`.
