### PR TITLE
Fixes undef var notice

### DIFF
--- a/Net/Gearman/Connection.php
+++ b/Net/Gearman/Connection.php
@@ -388,7 +388,7 @@ class Net_Gearman_Connection
 
         if ($success === 0) {
             $errno = @socket_last_error($this->socket);
-            throw new Net_Gearman_Exception("Socket timeout ($et): ($errno) ".socket_strerror($errno));
+            throw new Net_Gearman_Exception("Socket timeout ($timeout): ($errno) ".socket_strerror($errno));
         }
 
         $cmd = $this->read();


### PR DESCRIPTION
This fixes a minor issue with an undefined variable notice that will occur if the timeout is encountered.

```
[06-Aug-2018 16:03:23 UTC] PHP Notice:  Undefined variable: et in .../vendor/brianlmoon/net_gearman/Net/Gearman/Connection.php on line 391
```