### PR TITLE
Fix array to string conversion notice in Net_Gearman_Connection::blockingRead().

### DIFF
--- a/Net/Gearman/Connection.php
+++ b/Net/Gearman/Connection.php
@@ -388,7 +388,9 @@ class Net_Gearman_Connection
 
         if ($success === 0) {
             $errno = @socket_last_error($this->socket);
-            throw new Net_Gearman_Exception("Socket timeout ($timeout): ($errno) ".socket_strerror($errno));
+            throw new Net_Gearman_Exception(
+                sprintf("Socket timeout (%.4fs, %.4fμs): (%s) ", $timeout[0], $timeout[1], socket_strerror($errno))
+            );
         }
 
         $cmd = $this->read();


### PR DESCRIPTION
* Include both timeout as seconds and microseconds in exception message.
* Format timeout values to avoid display of potentially longer float values.

When `socket_select()` fails we throw a `Net_Gearman_Exception`, but its message is assuming that `$timeout` is scalar, when it's actually an array of number of seconds and microseconds.  This causes a notice.  Fix the notice, and include both values in the exception message.

Sample PHP notice before change:

```
PHP Notice:  Array to string conversion in /foo/bar/vendor/brianlmoon/net_gearman/Net/Gearman/Connection.php on line 391
```

Sample exception message after change:

```
Socket timeout (5.0000s, 5000.3134μs): (Connection timed out)
```