### PR TITLE
Remove trailing space from exception message.

### DIFF
--- a/Net/Gearman/Connection.php
+++ b/Net/Gearman/Connection.php
@@ -389,7 +389,7 @@ class Net_Gearman_Connection
         if ($success === 0) {
             $errno = @socket_last_error($this->socket);
             throw new Net_Gearman_Exception(
-                sprintf("Socket timeout (%.4fs, %.4fμs): (%s) ", $timeout[0], $timeout[1], socket_strerror($errno))
+                sprintf("Socket timeout (%.4fs, %.4fμs): (%s)", $timeout[0], $timeout[1], socket_strerror($errno))
             );
         }
 


### PR DESCRIPTION
* Remove trailing space from exception message in `Net_Gearman_Connection::blockingRead()` when `socket_select()` call results in an error.