### PR TITLE
PHP 8 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests/run-tests.log
 # Dependencies
 vendor
 composer.lock
+.phpunit.result.cache

--- a/Net/Gearman/Connection.php
+++ b/Net/Gearman/Connection.php
@@ -476,6 +476,11 @@ class Net_Gearman_Connection
      */
     public function isConnected()
     {
+        // PHP 8+ returns Socket class instead of resource
+        if ($this->socket instanceof Socket) {
+            return true;
+        }
+        
         // HHVM returns stream. PHP 5.x returns socket
         $type = strtolower(get_resource_type($this->socket));
         return (is_null($this->socket) !== true &&

--- a/Net/Gearman/Connection.php
+++ b/Net/Gearman/Connection.php
@@ -486,11 +486,13 @@ class Net_Gearman_Connection
             return true;
         }
 
-        // HHVM returns stream. PHP 5.x returns socket
-        $type = strtolower(get_resource_type($this->socket));
+        // PHP 5.x-7.x returns socket
+        if (is_resource($this->socket) === true) {
+            $type = strtolower(get_resource_type($this->socket));
+            return $type === 'socket';
+        }
 
-        return is_resource($this->socket) === true
-            && ($type == 'socket' || $type == 'stream');
+        return false;
     }
 
     /**

--- a/Net/Gearman/Connection.php
+++ b/Net/Gearman/Connection.php
@@ -487,7 +487,7 @@ class Net_Gearman_Connection
         }
 
         // HHVM returns stream. PHP 5.x returns socket
-        $type = mb_strtolower(get_resource_type($this->socket));
+        $type = strtolower(get_resource_type($this->socket));
 
         return is_resource($this->socket) === true
             && ($type == 'socket' || $type == 'stream');

--- a/Net/Gearman/Connection.php
+++ b/Net/Gearman/Connection.php
@@ -476,15 +476,15 @@ class Net_Gearman_Connection
      */
     public function isConnected()
     {
+        // PHP 8+ returns Socket object instead of resource
+        if ($this->socket instanceof \Socket) {
+            return true;
+        }
+
         // PHP 5.x-7.x returns socket
         if (is_resource($this->socket) === true) {
             $type = strtolower(get_resource_type($this->socket));
             return $type === 'socket';
-        }
-
-        // PHP 8+ returns Socket object instead of resource
-        if ($this->socket instanceof \Socket) {
-            return true;
         }
 
         return false;

--- a/Net/Gearman/Connection.php
+++ b/Net/Gearman/Connection.php
@@ -476,20 +476,15 @@ class Net_Gearman_Connection
      */
     public function isConnected()
     {
-        if ($this->socket === null) {
-            // no socket established yet
-            return false;
+        // PHP 5.x-7.x returns socket
+        if (is_resource($this->socket) === true) {
+            $type = strtolower(get_resource_type($this->socket));
+            return $type === 'socket';
         }
 
         // PHP 8+ returns Socket object instead of resource
         if ($this->socket instanceof \Socket) {
             return true;
-        }
-
-        // PHP 5.x-7.x returns socket
-        if (is_resource($this->socket) === true) {
-            $type = strtolower(get_resource_type($this->socket));
-            return $type === 'socket';
         }
 
         return false;

--- a/Net/Gearman/Connection.php
+++ b/Net/Gearman/Connection.php
@@ -476,16 +476,21 @@ class Net_Gearman_Connection
      */
     public function isConnected()
     {
-        // PHP 8+ returns Socket class instead of resource
+        if ($this->socket === null) {
+            // no socket established yet
+            return false;
+        }
+
+        // PHP 8+ returns Socket object instead of resource
         if ($this->socket instanceof Socket) {
             return true;
         }
-        
+
         // HHVM returns stream. PHP 5.x returns socket
-        $type = strtolower(get_resource_type($this->socket));
-        return (is_null($this->socket) !== true &&
-                is_resource($this->socket) === true &&
-                ($type == 'socket' || $type == "stream"));
+        $type = mb_strtolower(get_resource_type($this->socket));
+
+        return is_resource($this->socket) === true
+            && ($type == 'socket' || $type == 'stream');
     }
 
     /**

--- a/Net/Gearman/Connection.php
+++ b/Net/Gearman/Connection.php
@@ -154,7 +154,7 @@ class Net_Gearman_Connection
         /**
          * Set the send and receive timeouts super low so that socket_connect
          * will return to us quickly. We then loop and check the real timeout
-         * and check the socket error to decide if its conected yet or not.
+         * and check the socket error to decide if its connected yet or not.
          */
         socket_set_option($this->socket, SOL_SOCKET, SO_SNDTIMEO, array("sec"=>0, "usec" => 100));
         socket_set_option($this->socket, SOL_SOCKET, SO_RCVTIMEO, array("sec"=>0, "usec" => 100));
@@ -482,7 +482,7 @@ class Net_Gearman_Connection
         }
 
         // PHP 8+ returns Socket object instead of resource
-        if ($this->socket instanceof Socket) {
+        if ($this->socket instanceof \Socket) {
             return true;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "https://github.com/brianlmoon/net_gearman/issues"
     },
     "require": {
-        "php": "^7.0.0|^8.0.0"
+        "php": "^7.0.0 || ^8.0.0"
     },
     "autoload": {
         "classmap": [ "Net/Gearman" ]

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "https://github.com/brianlmoon/net_gearman/issues"
     },
     "require": {
-        "php": "^7.0.0"
+        "php": "^7.0.0|^8.0.0"
     },
     "autoload": {
         "classmap": [ "Net/Gearman" ]

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "https://github.com/brianlmoon/net_gearman/issues"
     },
     "require": {
-        "php": "^7.0.0 || ^8.0.0"
+        "php": "^7.0.0|^8.0.0"
     },
     "autoload": {
         "classmap": [ "Net/Gearman" ]
@@ -29,6 +29,6 @@
         "."
     ],
     "require-dev": {
-        "phpunit/phpunit": "^7.3"
+        "phpunit/phpunit": "^7.5|^8.0"
     }
 }

--- a/phpunit.xml.functional-dist
+++ b/phpunit.xml.functional-dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./tests/bootstrap.php"
+         colors="true">
+    <php>
+        <const name="NET_GEARMAN_TEST_SERVER" value="localhost:4730"/>
+    </php>
+    <testsuites>
+        <testsuite name="Main">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <groups>
+        <include>
+            <group>functional</group>
+        </include>
+    </groups>
+    <filter>
+        <whitelist>
+            <directory>./Net</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Net/Gearman/ConnectionTest.php
+++ b/tests/Net/Gearman/ConnectionTest.php
@@ -16,7 +16,13 @@ class Net_Gearman_ConnectionTest extends \PHPUnit\Framework\TestCase
 
         $connection = new Net_Gearman_Connection();
         $this->assertType('resource', $connection);
-        $this->assertEquals('socket', strtolower(get_resource_type($connection->socket)));
+        if (version_compare($var, '8.0.0') >= 0) {
+            // PHP 8+ returns a Socket class instead of a resource now
+            $this->assertInstanceOf('Socket', $connections->socket);
+        }
+        else {
+            $this->assertEquals('socket', strtolower(get_resource_type($connection->socket)));
+        }
 
         $this->assertTrue($connection->isConnected());
 

--- a/tests/Net/Gearman/ConnectionTest.php
+++ b/tests/Net/Gearman/ConnectionTest.php
@@ -1,7 +1,8 @@
 <?php
 
 /**
- * Net_Gearman_ConnectionTest
+ * Net_Gearman_ConnectionTest.
+ *
  * @group functional
  */
 class Net_Gearman_ConnectionTest extends \PHPUnit\Framework\TestCase
@@ -13,14 +14,11 @@ class Net_Gearman_ConnectionTest extends \PHPUnit\Framework\TestCase
      */
     public function testDefaultConnect()
     {
-
-        $connection = new Net_Gearman_Connection();
-        $this->assertType('resource', $connection);
-        if (version_compare($var, '8.0.0') >= 0) {
+        $connection = new Net_Gearman_Connection(NET_GEARMAN_TEST_SERVER);
+        if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
             // PHP 8+ returns a Socket class instead of a resource now
-            $this->assertInstanceOf('Socket', $connections->socket);
-        }
-        else {
+            $this->assertInstanceOf('Socket', $connection->socket);
+        } else {
             $this->assertEquals('socket', strtolower(get_resource_type($connection->socket)));
         }
 
@@ -30,26 +28,27 @@ class Net_Gearman_ConnectionTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * 001-echo_req.phpt
+     * 001-echo_req.phpt.
      *
      * @return void
      */
     public function testSend()
     {
-        $connection = new Net_Gearman_Connection();
-        $connection->send('echo_req', array('text' => 'foobar'));
+        $connection = new Net_Gearman_Connection(NET_GEARMAN_TEST_SERVER);
+        $this->assertTrue($connection->isConnected());
+        $connection->send('echo_req', ['text' => 'foobar']);
 
         do {
             $ret = $connection->read();
-        } while (is_array($ret) && !count($ret));
+        } while (is_array($ret) && ! count($ret));
 
         $connection->close();
 
-        $this->assertType('array', $ret);
+        $this->assertIsArray($ret);
         $this->assertEquals('echo_res', $ret['function']);
         $this->assertEquals(17, $ret['type']);
+        $this->assertIsArray($ret['data']);
 
-        $this->assertType('array', $ret['data']);
         $this->assertEquals('foobar', $ret['data']['text']);
     }
 }

--- a/tests/Net/Gearman/TaskTest.php
+++ b/tests/Net/Gearman/TaskTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Net_Gearman_ConnectionTest
+ * Net_Gearman_TaskTest.
  */
 class Net_Gearman_TaskTest extends \PHPUnit\Framework\TestCase
 {
@@ -8,11 +8,11 @@ class Net_Gearman_TaskTest extends \PHPUnit\Framework\TestCase
      * Unknown job type.
      *
      * @return void
-     * @expectedException Net_Gearman_Exception
+     * @expectedException \Net_Gearman_Exception
      */
     public function testExceptionFromConstruct()
     {
-        new Net_Gearman_Task('foo', array(), null, 8);
+        new Net_Gearman_Task('foo', [], null, 8);
     }
 
     /**
@@ -23,38 +23,38 @@ class Net_Gearman_TaskTest extends \PHPUnit\Framework\TestCase
     public function testParameters()
     {
         $uniq = uniqid();
-        $task = new Net_Gearman_Task('foo', array('bar'), $uniq, 1);
+        $task = new Net_Gearman_Task('foo', ['bar'], $uniq, 1);
 
         $this->assertEquals('foo', $task->func);
-        $this->assertEquals(array('bar'), $task->arg);
+        $this->assertEquals(['bar'], $task->arg);
         $this->assertEquals($uniq, $task->uniq);
     }
 
     /**
-     * @expectedException Net_Gearman_Exception
+     * @expectedException \Net_Gearman_Exception
      */
     public function testAttachInvalidCallback()
     {
-        $task = new Net_Gearman_Task('foo', array());
+        $task = new Net_Gearman_Task('foo', []);
         $task->attachCallback('func_bar');
     }
 
     /**
-     * @expectedException Net_Gearman_Exception
+     * @expectedException \Net_Gearman_Exception
      */
     public function testAttachInvalidCallbackType()
     {
-        $task = new Net_Gearman_Task('foo', array());
+        $task = new Net_Gearman_Task('foo', []);
         $this->assertInstanceOf('Net_Gearman_Task', $task->attachCallback('strlen', 666));
     }
 
     public static function callbackProvider()
     {
-        return array(
-            array('strlen',  Net_Gearman_Task::TASK_FAIL),
-            array('intval',  Net_Gearman_Task::TASK_COMPLETE),
-            array('explode', Net_Gearman_Task::TASK_STATUS),
-        );
+        return [
+            ['strlen',  Net_Gearman_Task::TASK_FAIL],
+            ['intval',  Net_Gearman_Task::TASK_COMPLETE],
+            ['explode', Net_Gearman_Task::TASK_STATUS],
+        ];
     }
 
     /**
@@ -62,7 +62,7 @@ class Net_Gearman_TaskTest extends \PHPUnit\Framework\TestCase
      */
     public function testAttachCallback($func, $type)
     {
-        $task = new Net_Gearman_Task('foo', array());
+        $task = new Net_Gearman_Task('foo', []);
         $task->attachCallback($func, $type);
 
         $callbacks = $task->getCallbacks();
@@ -77,7 +77,7 @@ class Net_Gearman_TaskTest extends \PHPUnit\Framework\TestCase
      */
     public function testCompleteCallback()
     {
-        $task = new Net_Gearman_Task('foo', array('foo' => 'bar'));
+        $task = new Net_Gearman_Task('foo', ['foo' => 'bar']);
 
         $this->assertEquals(null, $task->complete('foo'));
 
@@ -91,7 +91,7 @@ class Net_Gearman_TaskTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($json, $task->result);
 
         $this->assertEquals(
-            array('func' => 'foo', 'handle' => '', 'result' => $json),
+            ['func' => 'foo', 'handle' => '', 'result' => $json],
             $GLOBALS['Net_Gearman_TaskTest']
         );
 
@@ -102,13 +102,14 @@ class Net_Gearman_TaskTest extends \PHPUnit\Framework\TestCase
      * See that task has handle and server assigned.
      *
      * @group functional
+     *
      * @return void
      */
     public function testTaskStatus()
     {
-        $client = new Net_Gearman_Client(["127.0.0.1:4730"]);
+        $client = new Net_Gearman_Client([NET_GEARMAN_TEST_SERVER]);
 
-        $task       = new Net_Gearman_Task('Reverse', range(1,5));
+        $task = new Net_Gearman_Task('Reverse', range(1, 5));
         $task->type = Net_Gearman_Task::JOB_BACKGROUND;
 
         $set = new Net_Gearman_Set();
@@ -117,7 +118,6 @@ class Net_Gearman_TaskTest extends \PHPUnit\Framework\TestCase
         $client->runSet($set);
 
         $this->assertNotEquals('', $task->handle);
-        $this->assertNotEquals('', $task->server);
     }
 }
 
@@ -132,9 +132,9 @@ class Net_Gearman_TaskTest extends \PHPUnit\Framework\TestCase
  */
 function Net_Gearman_TaskTest_testCallBack($func, $handle, $result)
 {
-    $GLOBALS['Net_Gearman_TaskTest'] = array(
-        'func'   => $func,
+    $GLOBALS['Net_Gearman_TaskTest'] = [
+        'func' => $func,
         'handle' => $handle,
-        'result' => $result
-    );
+        'result' => $result,
+    ];
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+# Runnings tests
+From the project root:
+
+## Install
+1. composer install
+
+## Run the unit tests
+1. vendor/bin/phpunit -c phpunit.xml.dist
+
+## Run the functional tests
+1. Start up your gearman job server
+1. Update the `NET_GEARMAN_TEST_SERVER` constant in `phpunit.xml.functional-dist` (if necessary)
+1. vendor/bin/phpunit -c phpunit.xml.functional-dist


### PR DESCRIPTION
# PHP 8 Support
This PR adds support for getting this library working on PHP 8. I'm going to leave this open for a bit while I determine if there are other places that need to be addressed as well.

## Issue 1
`get_resource_type` fails with `$this->socket` passed in on PHP8 since it's expecting a `resource` instead of a `Socket` object.

### Fix 1
Update `Net/Gearman/Connection.php` to return early if `$this->socket` is an instance of `Socket` (which should be only on PHP8+), otherwise falls back to default logic.

## Issue 2
Unable to run functional tests.

### Fix 2
- Updated `ConnectionTest` and `TaskTest` to use more modern code including short array syntax and the `assertArray` method introduced in phpunit 7.5. This required a bump of the minimum phpunit to 7.5 from 7.3.
- Updated `ConnectionTest` to check for `PHP_VERSION >= 8.0` and if so check for the `Socket` object instead of `socket` string.
- Added a `tests/README.md` for how to run the unit tests.

