### PR TITLE
Silent return type notices under PHP 8.1

### DIFF
--- a/Net/Gearman/Set.php
+++ b/Net/Gearman/Set.php
@@ -194,6 +194,7 @@ class Net_Gearman_Set implements IteratorAggregate, Countable
      *
      * @return ArrayIterator Tasks
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->tasks);
@@ -205,6 +206,7 @@ class Net_Gearman_Set implements IteratorAggregate, Countable
      * @return int Number of tasks in the set
      * @see    {@link Countable::count()}
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->tasksCount;


### PR DESCRIPTION
Ok, there is only 2 notices, so it was done quickly adding the #[\ReturnTypeWillChange] attribute