### PR TITLE
Use #[AllowDynamicProperties] to suppress dynamic property notice in jobs

### DIFF
--- a/Net/Gearman/Job/Common.php
+++ b/Net/Gearman/Job/Common.php
@@ -34,6 +34,7 @@
  * @link      http://www.danga.com/gearman/
  * @see       Net_Gearman_Job_Common, Net_Gearman_Worker
  */
+#[\AllowDynamicProperties]
 abstract class Net_Gearman_Job_Common
 {
     /**


### PR DESCRIPTION
Another option is to add the property in Common.php as `$handle` and `$conn`:
```php
    /**
     * Parameters for Job instantiation
     * @var array $initParams
     */
    protected $initParams = array();
``` 
But this will break the user's jobs if someone declared the property with a type.