### PR TITLE
Update Worker.php

### DIFF
--- a/Net/Gearman/Worker.php
+++ b/Net/Gearman/Worker.php
@@ -440,7 +440,7 @@ class Net_Gearman_Worker
             $this->retryConnections();
 
             if (!empty($this->conn)) {
-                $worked = $this->askForWork();
+                $worked = $this->askForWork($monitor);
 
                 if ($worked) {
                     $lastJobTime = time();


### PR DESCRIPTION
Propagate monitor to askForWork.
In a multiserver configuration, if the $monitor would like to block the worker, it continues to work the jobs of the remaining servers until it finishes its loop before exiting.